### PR TITLE
fix: this.getLogger is not a function

### DIFF
--- a/src/server/VueSsrAssetsServerLoader.ts
+++ b/src/server/VueSsrAssetsServerLoader.ts
@@ -13,7 +13,7 @@ export function VueSsrAssetsServerPluginLoader(this: LoaderContext<VueSsrAssetsS
 
     const match = regex.exec(source)
     if (!match) {
-        const logger = this.getLogger(PLUGIN_NAME)
+        const logger = typeof this.getLogger === 'function' ? this.getLogger(PLUGIN_NAME) : console;
         logger.warn(`Failed to inject runtime code into "${options.componentName}"`)
         return source
     }


### PR DESCRIPTION
When the VueSsrAssetsServerPluginLoader cannot find the injection point for it's scripts, the compilation will crash because it cannot find this.getLogger()

Instead it should just ignore this silently or use a generic fallback